### PR TITLE
docs: fix Cursor MCP install config format

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -142,15 +142,20 @@ npm install n2-qln
 <details>
 <summary><strong>Cursor</strong></summary>
 
-**Settings → MCP Servers → Add Server**:
+`~/.cursor/mcp.json` (전역) 또는 `.cursor/mcp.json` (프로젝트)에 추가:
 
 ```json
 {
-  "name": "n2-qln",
-  "command": "npx",
-  "args": ["-y", "n2-qln"]
+  "mcpServers": {
+    "n2-qln": {
+      "command": "npx",
+      "args": ["-y", "n2-qln"]
+    }
+  }
 }
 ```
+
+또는 **Customize → MCPs**에서 동일한 설정을 추가하세요.
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -142,15 +142,20 @@ Edit `claude_desktop_config.json`:
 <details>
 <summary><strong>Cursor</strong></summary>
 
-Open **Settings → MCP Servers → Add Server**:
+Add to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project):
 
 ```json
 {
-  "name": "n2-qln",
-  "command": "npx",
-  "args": ["-y", "n2-qln"]
+  "mcpServers": {
+    "n2-qln": {
+      "command": "npx",
+      "args": ["-y", "n2-qln"]
+    }
+  }
 }
 ```
+
+Or open **Customize → MCPs** and add the same config there.
 </details>
 
 <details>


### PR DESCRIPTION
## Summary
- Cursor MCP setup in `README.md` / `README.ko.md` used an invalid flat `{ name, command, args }` payload and an outdated Settings path.
- Updated both docs to the real Cursor format: `mcpServers` in `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project), plus **Customize → MCPs**.

## Test plan
- [ ] Confirm the shown JSON matches Cursor’s MCP config schema
- [ ] Spot-check EN and KO Cursor sections for consistency with the Claude Desktop block

Made with [Cursor](https://cursor.com)